### PR TITLE
Compi: El componente BaseButton necesita color nuevo El componente Base Lu...

### DIFF
--- a/src/components/atoms/BaseButton.vue
+++ b/src/components/atoms/BaseButton.vue
@@ -91,7 +91,7 @@ export default defineComponent({
 }
 
 .base-button--primary {
-  background-color: var(--color-brand-500);
+  background-color: var(--color-primary-500);
   color: white;
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,6 +1,7 @@
 :root {
   --color-brand-500: #f541d8;
   --color-brand-600: #d127b5;
+  --color-primary-500: #3a3546;
   --color-surface: #f8fafc;
   --color-surface-alt: #e2e8f0;
   --color-text-primary: #0f172a;


### PR DESCRIPTION
## Justificación del Cambio

- Source: Compi task
- Branch: `compi/task-1773138739569-nxcr3e`
- Created at: 2026-03-10T10:33:34.773Z

## 🧠 Razonamiento
Implemented: El componente BaseButton necesita color nuevo El componente Base Luton necesita un nuevo color Primary: #3A3546.

Updated implementation in src/components/atoms/BaseButton.vue, src/styles/tokens.css.

Diff footprint:
```
src/components/atoms/BaseButton.vue | 2 +-
 src/styles/tokens.css               | 1 +
 2 files changed, 2 insertions(+), 1 deletion(-)
```

Goose signals:
- __( O)>  ● new session · openrouter minimax/minimax-m2.5
- \____)    20260310_1 · /workspace
- L L     goose is ready
- ▸ tree
- path: /workspace/src
- depth: 3
- components/  [2K]
- atoms/  [2K]

Key patch excerpts:
```diff
diff --git a/src/components/atoms/BaseButton.vue b/src/components/atoms/BaseButton.vue
index e1bc2b2..206bd01 100644
--- a/src/components/atoms/BaseButton.vue
+++ b/src/components/atoms/BaseButton.vue
@@ -94 +94 @@ export default defineComponent({
-  background-color: var(--color-brand-500);
+  background-color: var(--color-primary-500);
diff --git a/src/styles/tokens.css b/src/styles/tokens.css
index c6ad7a4..c44f07b 100644
--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -3,0 +4 @@
+  --color-primary-500: #3a3546;
```

### Prompt
El prompt se omite del cuerpo de la PR por seguridad.