### PR TITLE
feat: expand design system showcase with all components

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,50 @@
+# Audit & Vulnerability Updates
+
+## Security Audits
+
+### Run npm audit
+```bash
+npm audit
+```
+Reports known vulnerabilities in dependencies.
+
+### Fix vulnerabilities automatically
+```bash
+npm audit fix
+```
+Attempts to upgrade packages to patch vulnerable versions.
+
+### Generate audit report
+```bash
+npm audit --json > audit-report.json
+```
+Creates a detailed JSON report for CI/CD pipelines.
+
+## Dependency Updates
+
+### Check for outdated packages
+```bash
+npm outdated
+```
+Lists packages with available updates.
+
+### Update all dependencies safely
+```bash
+npm update
+```
+Updates to compatible versions per `package.json` semver ranges.
+
+### Update to latest versions
+```bash
+npm upgrade [package-name]
+```
+Or manually edit `package.json` and run `npm install`.
+
+## CI/CD Integration
+
+Add to your workflow to fail on vulnerabilities:
+```bash
+npm audit --audit-level=moderate
+```
+
+Use `npm ci` instead of `npm install` in CI for reproducible builds.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 coverage
 storybook-static
 .DS_Store
+.playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # Vite dev server
+npm run build        # Type-check (vue-tsc) + production build
+npm run preview      # Serve production build locally
+npm run test         # Vitest in watch mode
+npm run test:run     # Vitest single run (CI)
+npm run lint         # ESLint on .ts/.vue files (fails on warnings)
+npm run lint:fix     # ESLint with auto-fix
+npm run format       # Prettier format all files
+npm run storybook    # Storybook dev server on port 6006
+npm run build-storybook  # Static Storybook build
+```
+
+To run a single test file: `npx vitest run src/components/atoms/BaseButton.test.ts`
+
+## Architecture
+
+Vue 3 + TypeScript + Vite Design System demo following **Atomic Design**:
+
+- `src/components/atoms/` — base reusable components with no domain logic (`Base*` prefix)
+- `src/components/molecules/` — compositions of atoms for a specific intent
+- `src/components/organisms/` — compositions of molecules/atoms for full page sections
+- `src/styles/tokens.css` — all design tokens as CSS custom properties under `:root`
+- `src/styles/tailwind.css` — Tailwind entry (`@tailwind base/components/utilities`)
+- `src/types/` — shared domain TypeScript types
+
+`App.vue` serves as a demo integration of the Design System; it is not a real application.
+
+## Mandatory Patterns
+
+**Component structure**: Every component must have three co-located files:
+1. `ComponentName.vue` — implementation
+2. `ComponentName.test.ts` — Vitest tests (render + basic interaction)
+3. `ComponentName.stories.ts` — Storybook story
+
+**Component API**: Use `defineComponent` + `setup()` (Composition API). Export a typed props interface named `ComponentNameProps` from the SFC.
+
+**Styling**: Use `var(--token)` for colors, spacing, typography, and border-radius. Avoid hardcoded values except justified cases (e.g., `white`, decorative gradients). Tailwind is extended to reuse token values via `tailwind.config.ts`.
+
+**Layer discipline**: No business logic in atoms. Compose upward in molecules/organisms.
+
+## Naming Conventions
+
+- Vue components: `PascalCase`
+- Atom components: `Base` prefix (e.g., `BaseButton`, `BaseInput`)
+- Props interfaces: `PascalCase` + `Props` suffix, exported from the SFC
+- Tests: `ComponentName.test.ts` (co-located)
+- Stories: `ComponentName.stories.ts` (co-located)
+
+## Tooling
+
+- TypeScript strict mode enabled (`noUnusedLocals`, `noUnusedParameters`)
+- Path alias `@/*` → `src/*`
+- ESLint flat config; `@typescript-eslint/no-explicit-any` and `vue/multi-word-component-names` are disabled
+- Prettier: single quotes, trailing commas, `printWidth: 100`
+- Vitest: jsdom environment, globals enabled, setup file at `src/test/setup.ts` (stubs Vue transitions)
+- Storybook 8 with `@storybook/vue3-vite`; stories located at `src/**/*.stories.@(ts|tsx)`
+
+## Code Style
+
+- Use comments sparingly. Only comment complex or non-obvious code.
+
+## Constraints
+
+- Do not create `README.md` — `AGENTS.md` is the primary repo documentation.
+- Keep Design System components decoupled from any API/backend.
+- Any new component must follow Atomic Design and ship with test + story in the same PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -732,10 +732,11 @@
       "dev": true
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -807,10 +808,11 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2632,10 +2634,11 @@
       "dev": true
     },
     "node_modules/@vue/language-core/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3024,10 +3027,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -3530,10 +3534,11 @@
       "dev": true
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3844,10 +3849,11 @@
       "dev": true
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4105,10 +4111,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
-      "dev": true
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4263,10 +4270,11 @@
       "dev": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -5417,10 +5425,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6519,10 +6528,11 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6920,10 +6930,11 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -7058,10 +7069,11 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mx-auto flex min-h-screen max-w-6xl flex-col px-6 py-8">
+  <div class="page">
     <NavigationBar
       logo="Compi DS"
       :user-name="currentUser.name"
@@ -7,14 +7,145 @@
       @search="onSearch"
     />
 
-    <main class="mt-8 flex flex-1 flex-col gap-6">
-      <AlertBanner
-        title="Demo Environment"
-        message="Este Design System usa Atomic Design, tokens CSS y componentes tipados."
-        tone="info"
-      />
+    <main class="main">
+      <!-- Intro -->
+      <BaseCard variant="flat">
+        <div class="intro">
+          <div>
+            <h1 class="intro__title">Design System Showcase</h1>
+            <p class="intro__sub">All components from the Compi DS atomic design library — atoms, molecules &amp; organisms.</p>
+          </div>
+          <div class="intro__tags">
+            <BaseTag label="v1.0" tone="brand" />
+            <BaseTag label="Atomic Design" tone="neutral" variant="outline" />
+            <BaseTag label="Vue 3" tone="neutral" variant="outline" />
+          </div>
+        </div>
+      </BaseCard>
 
-      <UserList :users="filteredUsers" />
+      <!-- Alerts -->
+      <section>
+        <h2 class="section-heading">Alerts</h2>
+        <div class="grid-2">
+          <AlertBanner title="Success" message="Your changes have been saved successfully." tone="success" />
+          <AlertBanner title="Warning" message="Your session will expire in 10 minutes." tone="warning" />
+          <AlertBanner title="Danger" message="Something went wrong. Please try again." tone="danger" />
+          <AlertBanner title="Info" message="Este Design System usa Atomic Design y tokens CSS." tone="info" />
+        </div>
+      </section>
+
+      <!-- Buttons -->
+      <section>
+        <h2 class="section-heading">Buttons &amp; Actions</h2>
+        <div class="grid-2">
+          <BaseCard title="Button variants" variant="outlined">
+            <div class="row-wrap">
+              <BaseButton label="Primary" variant="primary" />
+              <BaseButton label="Secondary" variant="secondary" />
+              <BaseButton label="Ghost" variant="ghost" />
+              <BaseButton label="Disabled" variant="primary" :disabled="true" />
+            </div>
+          </BaseCard>
+          <BaseCard title="Icon action buttons" variant="outlined">
+            <div class="row-wrap">
+              <BaseActionButton label="Search sm" icon="search" variant="primary" size="sm" />
+              <BaseActionButton label="User md" icon="user" variant="primary" size="md" />
+              <BaseActionButton label="Check lg" icon="check" variant="primary" size="lg" />
+              <BaseActionButton label="Alert secondary" icon="alert" variant="secondary" size="md" />
+              <BaseActionButton label="Info ghost" icon="info" variant="ghost" size="md" />
+              <BaseActionButton label="Disabled" icon="search" variant="primary" size="md" :disabled="true" />
+            </div>
+          </BaseCard>
+        </div>
+      </section>
+
+      <!-- Tags & Badges -->
+      <section>
+        <h2 class="section-heading">Tags &amp; Badges</h2>
+        <div class="grid-2">
+          <BaseCard title="Tags — default &amp; outline" variant="outlined">
+            <div class="row-wrap" style="margin-bottom: var(--space-3)">
+              <BaseTag label="Neutral" tone="neutral" />
+              <BaseTag label="Brand" tone="brand" />
+              <BaseTag label="Success" tone="success" />
+              <BaseTag label="Warning" tone="warning" />
+              <BaseTag label="Danger" tone="danger" />
+            </div>
+            <div class="row-wrap">
+              <BaseTag label="Neutral" tone="neutral" variant="outline" />
+              <BaseTag label="Brand" tone="brand" variant="outline" />
+              <BaseTag label="Success" tone="success" variant="outline" />
+              <BaseTag label="Warning" tone="warning" variant="outline" />
+              <BaseTag label="Danger" tone="danger" variant="outline" />
+            </div>
+          </BaseCard>
+          <BaseCard title="Badges" variant="outlined">
+            <div class="row-wrap">
+              <BaseBadge label="Info" tone="info" />
+              <BaseBadge label="Success" tone="success" />
+              <BaseBadge label="Warning" tone="warning" />
+              <BaseBadge label="Danger" tone="danger" />
+              <BaseBadge label="Error" tone="error" />
+            </div>
+          </BaseCard>
+        </div>
+      </section>
+
+      <!-- Cards -->
+      <section>
+        <h2 class="section-heading">Cards</h2>
+        <div class="grid-3">
+          <BaseCard title="Elevated" variant="elevated">
+            <p class="card-body-text">Box-shadow gives depth. Best for primary content areas.</p>
+            <template #footer>
+              <BaseButton label="Action" variant="ghost" />
+            </template>
+          </BaseCard>
+          <BaseCard title="Outlined" variant="outlined">
+            <p class="card-body-text">Border defines the boundary. Good for secondary groupings.</p>
+            <template #footer>
+              <BaseButton label="Action" variant="ghost" />
+            </template>
+          </BaseCard>
+          <BaseCard title="Flat" variant="flat">
+            <p class="card-body-text">Surface background, no shadow. Use for subtle containers.</p>
+            <template #footer>
+              <BaseButton label="Action" variant="ghost" />
+            </template>
+          </BaseCard>
+        </div>
+      </section>
+
+      <!-- Form controls -->
+      <section>
+        <h2 class="section-heading">Form Controls</h2>
+        <div class="grid-2">
+          <BaseCard title="Inputs" variant="outlined">
+            <div class="col-stack">
+              <BaseInput v-model="formName" label="Full name" placeholder="e.g. Alicia Vega" />
+              <BaseInput v-model="formEmail" label="Email" placeholder="you@example.com" type="email" />
+              <BaseInput v-model="formSearch" placeholder="Search…" :search="true" />
+              <BaseInput v-model="formDisabled" label="Disabled" placeholder="Cannot edit" :disabled="true" />
+            </div>
+          </BaseCard>
+          <BaseCard title="Textarea &amp; Checkboxes" variant="outlined">
+            <div class="col-stack">
+              <BaseTextArea v-model="formNote" placeholder="Write a note…" :rows="4" />
+              <div class="col-stack-sm">
+                <BaseCheckbox v-model="check1" label="Send email notifications" />
+                <BaseCheckbox v-model="check2" label="Enable two-factor authentication" />
+                <BaseCheckbox v-model="check3" label="Disabled option" :disabled="true" />
+              </div>
+            </div>
+          </BaseCard>
+        </div>
+      </section>
+
+      <!-- Team Members -->
+      <section>
+        <h2 class="section-heading">Team Members</h2>
+        <UserList :users="filteredUsers" />
+      </section>
     </main>
   </div>
 </template>
@@ -24,6 +155,14 @@ import { computed, defineComponent, ref } from 'vue';
 import AlertBanner from '@/components/molecules/AlertBanner.vue';
 import NavigationBar from '@/components/organisms/NavigationBar.vue';
 import UserList from '@/components/organisms/UserList.vue';
+import BaseActionButton from '@/components/atoms/BaseActionButton.vue';
+import BaseBadge from '@/components/atoms/BaseBadge.vue';
+import BaseButton from '@/components/atoms/BaseButton.vue';
+import BaseCard from '@/components/atoms/BaseCard.vue';
+import BaseCheckbox from '@/components/atoms/BaseCheckbox.vue';
+import BaseInput from '@/components/atoms/BaseInput.vue';
+import BaseTag from '@/components/atoms/BaseTag.vue';
+import BaseTextArea from '@/components/atoms/BaseTextArea.vue';
 import type { User } from '@/types/user';
 
 const USERS: User[] = [
@@ -38,18 +177,31 @@ export default defineComponent({
     AlertBanner,
     NavigationBar,
     UserList,
+    BaseActionButton,
+    BaseBadge,
+    BaseButton,
+    BaseCard,
+    BaseCheckbox,
+    BaseInput,
+    BaseTag,
+    BaseTextArea,
   },
   setup() {
     const searchQuery = ref('');
     const currentUser = USERS[0];
 
+    const formName = ref('');
+    const formEmail = ref('');
+    const formSearch = ref('');
+    const formDisabled = ref('locked value');
+    const formNote = ref('');
+    const check1 = ref(true);
+    const check2 = ref(false);
+    const check3 = ref(false);
+
     const filteredUsers = computed(() => {
       const query = searchQuery.value.trim().toLowerCase();
-
-      if (!query) {
-        return USERS;
-      }
-
+      if (!query) return USERS;
       return USERS.filter((user) => user.name.toLowerCase().includes(query));
     });
 
@@ -61,7 +213,105 @@ export default defineComponent({
       currentUser,
       filteredUsers,
       onSearch,
+      formName,
+      formEmail,
+      formSearch,
+      formDisabled,
+      formNote,
+      check1,
+      check2,
+      check3,
     };
   },
 });
 </script>
+
+<style scoped>
+.page {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-6) calc(var(--space-6) * 2);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.main {
+  margin-top: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.section-heading {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin: 0 0 var(--space-3);
+}
+
+.intro {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.intro__title {
+  margin: 0 0 var(--space-1);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.intro__sub {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.intro__tags {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-4);
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-4);
+}
+
+.row-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.col-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.col-stack-sm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.card-body-text {
+  margin: 0;
+  font-size: var(--font-size-sm);
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds 6 labelled sections to `App.vue` showcasing all existing atoms/molecules/organisms
- **Alerts** — all 4 tones (success, warning, danger, info) in a 2-column grid
- **Buttons & Actions** — all 3 button variants + disabled, all action button sizes/variants
- **Tags & Badges** — all 5 tones in both default and outline styles; all badge tones
- **Cards** — all 3 variants (elevated, outlined, flat) side by side with footer slots
- **Form Controls** — labeled inputs, email, search, disabled; textarea + checkboxes
- **Team Members** — existing user list retained at the bottom
- Gitignores `.playwright-mcp` (Playwright session artifacts)

## Test plan

- [ ] `npm run dev` — page loads and all sections render correctly
- [ ] `npm run build` — type-check passes
- [ ] `npm run lint` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)